### PR TITLE
Get rid of double const specification

### DIFF
--- a/drivers/usb/eth/r8152.c
+++ b/drivers/usb/eth/r8152.c
@@ -26,7 +26,7 @@ struct r8152_dongle {
 	unsigned short product;
 };
 
-static const struct r8152_dongle const r8152_dongles[] = {
+static const struct r8152_dongle r8152_dongles[] = {
 	/* Realtek */
 	{ 0x0bda, 0x8050 },
 	{ 0x0bda, 0x8152 },
@@ -59,7 +59,7 @@ struct r8152_version {
 	bool           gmii;
 };
 
-static const struct r8152_version const r8152_versions[] = {
+static const struct r8152_version r8152_versions[] = {
 	{ 0x4c00, RTL_VER_01, 0 },
 	{ 0x4c10, RTL_VER_02, 0 },
 	{ 0x5c00, RTL_VER_03, 1 },


### PR DESCRIPTION
The duplicate const keyword causes a compile time error with gcc 7.2.

Signed-off-by: Bernhard Rosenkraenzer <bero@lindev.ch>