### PR TITLE
efi_loader: fix building crt0 with binutils 2.30+

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -262,6 +262,8 @@ S:	Maintained
 F:	include/efi_loader.h
 F:	lib/efi_loader/
 F:	cmd/bootefi.c
+F:	include/pe.h
+F:	include/asm-generic/pe.h
 
 FLATTENED DEVICE TREE
 M:	Simon Glass <sjg@chromium.org>

--- a/arch/arm/lib/crt0_aarch64_efi.S
+++ b/arch/arm/lib/crt0_aarch64_efi.S
@@ -8,6 +8,8 @@
  * This file is taken and modified from the gnu-efi project.
  */
 
+#include <asm-generic/pe.h>
+
 	.section	.text.head
 
 	/*
@@ -62,7 +64,7 @@ extra_header_fields:
 	 */
 	.long	_start - ImageBase		/* SizeOfHeaders */
 	.long	0				/* CheckSum */
-	.short	EFI_SUBSYSTEM			/* Subsystem */
+	.short	IMAGE_SUBSYSTEM_EFI_APPLICATION /* Subsystem */
 	.short	0				/* DllCharacteristics */
 	.quad	0				/* SizeOfStackReserve */
 	.quad	0				/* SizeOfStackCommit */

--- a/arch/arm/lib/crt0_arm_efi.S
+++ b/arch/arm/lib/crt0_arm_efi.S
@@ -8,6 +8,8 @@
  * This file is taken and modified from the gnu-efi project.
  */
 
+#include <asm-generic/pe.h>
+
 	.section	.text.head
 
 	/*
@@ -64,7 +66,7 @@ extra_header_fields:
 	 */
 	.long	_start - image_base		/* SizeOfHeaders */
 	.long	0				/* CheckSum */
-	.short	EFI_SUBSYSTEM			/* Subsystem */
+	.short	IMAGE_SUBSYSTEM_EFI_APPLICATION	/* Subsystem */
 	.short	0				/* DllCharacteristics */
 	.long	0				/* SizeOfStackReserve */
 	.long	0				/* SizeOfStackCommit */

--- a/include/asm-generic/pe.h
+++ b/include/asm-generic/pe.h
@@ -1,0 +1,21 @@
+/*
+ *  Portable Executable and Common Object Constants
+ *
+ *  Copyright (c) 2018 Heinrich Schuchardt
+ *
+ *  based on the "Microsoft Portable Executable and Common Object File Format
+ *  Specification", revision 11, 2017-01-23
+ *
+ *  SPDX-License-Identifier:     GPL-2.0+
+ */
+
+#ifndef _ASM_PE_H
+#define _ASM_PE_H
+
+/* Subsystem type */
+#define IMAGE_SUBSYSTEM_EFI_APPLICATION		10
+#define IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER	11
+#define IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER	12
+#define IMAGE_SUBSYSTEM_EFI_ROM			13
+
+#endif /* _ASM_PE_H */

--- a/include/pe.h
+++ b/include/pe.h
@@ -11,6 +11,8 @@
 #ifndef _PE_H
 #define _PE_H
 
+#include <asm-generic/pe.h>
+
 typedef struct _IMAGE_DOS_HEADER {
 	uint16_t e_magic;	/* 00: MZ Header signature */
 	uint16_t e_cblp;	/* 02: Bytes on last page of file */
@@ -43,7 +45,6 @@ typedef struct _IMAGE_DOS_HEADER {
 #define IMAGE_FILE_MACHINE_ARM64	0xaa64
 #define IMAGE_NT_OPTIONAL_HDR32_MAGIC	0x10b
 #define IMAGE_NT_OPTIONAL_HDR64_MAGIC	0x20b
-#define IMAGE_SUBSYSTEM_EFI_APPLICATION	10
 
 typedef struct _IMAGE_FILE_HEADER {
 	uint16_t Machine;


### PR DESCRIPTION
Before the patch an undefined constant EFI_SUBSYSTEM was used in the
crt0 code. The current version of binutils does not swallow the error.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=888403

The necessary constant IMAGE_SUBSYSTEM_EFI_APPLICATION is already
defined in pe.h. So let's factor out asm-generic/pe.h for the
image subsystem constants and use it in our assembler code.

IMAGE_SUBSYSTEM_SAL_RUNTIME_DRIVER does not exist in the specification
let's use IMAGE_SUBSYSTEM_EFI_ROM instead.

The include pe.h is only used in code maintained by Alex so let him be the
maintainer here too.

Author: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reported-by: Andre Przywara <andre.przywara@arm.com>
Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Tested-by: Vagrant Cascadian <vagrant@debian.org>
Signed-off-by: Alexander Graf <agraf@suse.de>
[bero@lindev.ch: Backported from u-boot master to marvell 17.10 tree]
Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>
Tested-by: Bernhard Rosenkränzer <bero@lindev.ch>