### PR TITLE
Update document trusted_boot.txt for A3700 platforms.

### DIFF
--- a/doc/mvebu/trusted_boot.txt
+++ b/doc/mvebu/trusted_boot.txt
@@ -256,7 +256,7 @@ A3700 platforms
 	d. efuse write KAK_DIGEST <otphash_value>
 	e. efuse write CSK_INDEX <key_index>
 	f. efuse write OPER_MODE <mode_type> (mode_type should be always 2).
-	g. efuse DEV_DEPLOY <deploy_value> (1 - enable/0 - disable), this command
+	g. efuse write DEV_DEPLOY <deploy_value> (1 - enable/0 - disable), this command
 	   will set the chip into trusted mode. It will also hide the AES-256 key.
 5. Burn the TRUSTED boot image using regular "bubt" command.
 6. Reset the board and verify that the trusted boot mode works.
@@ -318,22 +318,22 @@ A3700 platforms
    previous chapter for detailed description.
    For instance, the following sample content is from timnsign.txt::
 
-      DSA Algorithm ID:                7			; Signed with CSK6
+      DSA Algorithm ID:                7			; Signed with CSK3
       Hash Algorithm ID:               32
       Key Size in bits:                2048
       RSA Public Exponent
-	  ... ... ... ...(aligned with CSK6 file)
+	  ... ... ... ...(aligned with CSK3 file)
 	  ... ... ... ...
 	  RSA System Modulus:
-	  ... ... ... ...(aligned with CSK6 file)
+	  ... ... ... ...(aligned with CSK3 file)
 	  ... ... ... ...
 	  RSA Private Key:
-	  ... ... ... ...(aligned with CSK6 file)
+	  ... ... ... ...(aligned with CSK3 file)
 	  ... ... ... ...
 
    The key_index will be used in the following form in eFuse CSK_INDEX write command::
 
-      efuse write CSK_INDEX 6
+      efuse write CSK_INDEX 3
 
 i.e.
 
@@ -343,7 +343,7 @@ Default commands before bubt Secure Trusted boot image::
 	efuse write AES256_KEY 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF
 	efuse write BOOT_DEVICE SPINOR
 	efuse write KAK_DIGEST C27B72422C69997A33CC58B13CDB7EED25CD518B6E814E3459C9AFD91887C298
-	efuse write CSK_INDEX 6
+	efuse write CSK_INDEX 3
 	efuse write OPER_MODE 2
 
 


### PR DESCRIPTION
For users implementing Marvell's trusted bootloader, the document under `doc/mvebu/trusted_boot.txt` is key. This pull request includes minor changes to this document.

- The `efuse DEV_DEPLOY` is missing the `write` argument before `DEV_DEPLOY`
- The CSK index number, used in A3700-utils-marvell 17.10 release branch, is 3.
    [timnsign.txt A3700 utils marvell 17.10](https://github.com/MarvellEmbeddedProcessors/A3700-utils-marvell/blob/A3700_utils-armada-17.10/tim/trusted/timnsign.txt#L1)