### PR TITLE
Fix build with gcc 8

### DIFF
--- a/include/linux/log2.h
+++ b/include/linux/log2.h
@@ -15,7 +15,7 @@
 /*
  * deal with unrepresentable constant logarithms
  */
-extern __attribute__((const, noreturn))
+extern __attribute__((noreturn))
 int ____ilog2_NaN(void);
 
 /*


### PR DESCRIPTION
gcc 8 complains about the impossible combination of attributes noreturn
and const (if it doesn't return, it can't leave the system state
unchanged - so can't be const).

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>